### PR TITLE
Define MVP program account model + constants

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -19,3 +19,6 @@ Most relevant sample patterns:
 - `apps/mobile` implements it using Mobile Wallet Adapter (Seeker-compatible).
 - `apps/web` implements it using standard web wallet adapters later.
 
+
+## Program design docs
+- Account model + constants: `docs/program/account-model.md`

--- a/docs/program/account-model.md
+++ b/docs/program/account-model.md
@@ -1,0 +1,71 @@
+# Program Account Model (Issue #1)
+
+MVP constraints:
+- SOL-only escrow
+- Winner-only market
+- Add-to-position betting (user can place multiple bets on same driver in same market)
+- No floats, no `Vec<String>` on-chain
+
+## Seeds
+
+### Market PDA
+- Seeds: `b"market"`, `race_id_hash[32]`
+- One market per race.
+
+### Position PDA (user bet position)
+- Seeds: `b"position"`, `market_pubkey`, `user_pubkey`
+- Exactly one position account per `(market, user)`.
+- Additive betting only on same `driver_index`.
+
+## Constants
+- `MAX_DRIVERS = 20`
+- `FEE_BPS = 500` (5%, configurable per market)
+- `BPS_DENOMINATOR = 10_000`
+- `MIN_BET_LAMPORTS = 1_000_000` (0.001 SOL, tuning value)
+
+## Account shapes
+
+### Market
+- `authority: Pubkey`
+- `race_id_hash: [u8; 32]`
+- `open_ts: i64`
+- `close_ts: i64`
+- `status: u8` (`Open=0, Settled=1, Cancelled=2`)
+- `winner_index: u8` (`255` = unset)
+- `driver_count: u8` (must be `<= 20`)
+- `fee_bps: u16`
+- `total_pool_lamports: u64`
+- `driver_pools_lamports: [u64; 20]`
+- `winner_pool_lamports: u64`
+- `bump: u8`
+
+### Position
+- `user: Pubkey`
+- `market: Pubkey`
+- `driver_index: u8`
+- `amount_lamports: u64`
+- `claimed: bool`
+- `last_bet_ts: i64`
+- `bump: u8`
+
+## Rules
+- `create_market`
+  - `driver_count in 2..=20`
+  - `close_ts > open_ts`
+- `place_bet`
+  - market status must be open
+  - now `< close_ts`
+  - amount `>= MIN_BET_LAMPORTS`
+  - if position exists: must use same `driver_index`, then increment `amount_lamports`
+- `settle_market`
+  - after `close_ts`
+  - one-time operation
+  - set `winner_index` and `winner_pool_lamports`
+- `claim`
+  - requires settled market
+  - one-time per position
+  - payout math uses integer arithmetic only
+
+## Notes
+- Driver metadata (names, images, stats) stays off-chain in app/API.
+- Real-time odds come from market account subscription and client-side calculation.

--- a/programs/pitstop_protocol/src/constants.rs
+++ b/programs/pitstop_protocol/src/constants.rs
@@ -1,0 +1,5 @@
+pub const MAX_DRIVERS: usize = 20;
+pub const BPS_DENOMINATOR: u16 = 10_000;
+pub const DEFAULT_FEE_BPS: u16 = 500; // 5%
+pub const MIN_BET_LAMPORTS: u64 = 1_000_000; // 0.001 SOL
+pub const WINNER_UNSET: u8 = 255;

--- a/programs/pitstop_protocol/src/lib.rs
+++ b/programs/pitstop_protocol/src/lib.rs
@@ -1,0 +1,18 @@
+use anchor_lang::prelude::*;
+
+pub mod constants;
+pub mod state;
+
+declare_id!("PitSTop111111111111111111111111111111111111");
+
+#[program]
+pub mod pitstop_protocol {
+    use super::*;
+
+    pub fn placeholder(_ctx: Context<Placeholder>) -> Result<()> {
+        Ok(())
+    }
+}
+
+#[derive(Accounts)]
+pub struct Placeholder {}

--- a/programs/pitstop_protocol/src/state.rs
+++ b/programs/pitstop_protocol/src/state.rs
@@ -1,0 +1,37 @@
+use anchor_lang::prelude::*;
+use crate::constants::MAX_DRIVERS;
+
+#[repr(u8)]
+#[derive(AnchorSerialize, AnchorDeserialize, Clone, Copy, PartialEq, Eq, Debug)]
+pub enum MarketStatus {
+    Open = 0,
+    Settled = 1,
+    Cancelled = 2,
+}
+
+#[account]
+pub struct Market {
+    pub authority: Pubkey,
+    pub race_id_hash: [u8; 32],
+    pub open_ts: i64,
+    pub close_ts: i64,
+    pub status: u8,
+    pub winner_index: u8,
+    pub driver_count: u8,
+    pub fee_bps: u16,
+    pub total_pool_lamports: u64,
+    pub driver_pools_lamports: [u64; MAX_DRIVERS],
+    pub winner_pool_lamports: u64,
+    pub bump: u8,
+}
+
+#[account]
+pub struct Position {
+    pub user: Pubkey,
+    pub market: Pubkey,
+    pub driver_index: u8,
+    pub amount_lamports: u64,
+    pub claimed: bool,
+    pub last_bet_ts: i64,
+    pub bump: u8,
+}


### PR DESCRIPTION
Implements issue #1 by defining and documenting the on-chain account model and constants for MVP.\n\nIncludes:\n- Market/Position PDA seed decisions (doc)\n- Fixed-size driver pools (20)\n- Fee/constants and close-time rules\n- Rust state structs + constants scaffold under programs/pitstop_protocol\n\nCloses #1