### PR TITLE
Lock remaining top-level specs before initialize implementation

### DIFF
--- a/SPEC_ACCOUNTS.md
+++ b/SPEC_ACCOUNTS.md
@@ -1,6 +1,6 @@
 # SPEC_ACCOUNTS.md
-Version: v1.0.1
-Status: DRAFT
+Version: v1.0.2
+Status: LOCKED
 
 Canonical account layout contract.
 

--- a/SPEC_CANONICAL.md
+++ b/SPEC_CANONICAL.md
@@ -1,6 +1,6 @@
 # SPEC_CANONICAL.md
-Version: v1.0.0
-Status: DRAFT
+Version: v1.0.1
+Status: LOCKED
 
 ## Canonical descriptor encoding
 - UTF-8 JSON

--- a/SPEC_INSTRUCTIONS/INDEX.md
+++ b/SPEC_INSTRUCTIONS/INDEX.md
@@ -1,6 +1,6 @@
 # SPEC_INSTRUCTIONS/INDEX.md
-Version: v1.0.5
-Status: DRAFT (inventory locked; per-instruction status varies)
+Version: v1.0.6
+Status: LOCKED
 
 Authoritative instruction inventory for MVP (count: 12).
 
@@ -15,7 +15,7 @@ Authoritative instruction inventory for MVP (count: 12).
 | 7 | resolve_market | LOCKED | N | Y | Locked->Resolved | integration + adversarial |
 | 8 | void_market | LOCKED | N | Y | Locked->Voided | integration |
 | 9 | claim_resolved | LOCKED | Y | Y | N | integration + invariant |
-|10 | claim_voided | Draft | Y | Y | N | integration + invariant |
+|10 | claim_voided | LOCKED | Y | Y | N | integration + invariant |
 |11 | sweep_remaining | LOCKED | Y | Y | Resolved/Voided->Swept (terminal accounting) | integration + adversarial |
 |12 | cancel_market | LOCKED | Y | Y | Seeding->Voided | integration + adversarial |
 

--- a/SPEC_PROTOCOL.md
+++ b/SPEC_PROTOCOL.md
@@ -1,6 +1,6 @@
 # SPEC_PROTOCOL.md
-Version: v1.0.3
-Status: DRAFT (lock after instruction specs + harness are complete)
+Version: v1.0.4
+Status: LOCKED
 
 ## Purpose
 Single source of truth for PitStop protocol behavior.

--- a/SPEC_STATE_SCHEMA.md
+++ b/SPEC_STATE_SCHEMA.md
@@ -1,10 +1,10 @@
 # SPEC_STATE_SCHEMA.md
-Version: v1.0.0
-Status: DRAFT
+Version: v1.0.1
+Status: LOCKED
 
 Defines canonical account schemas and field semantics for Config/Market/OutcomePool/Position.
 
-## Config (draft)
+## Config
 - authority: Pubkey
 - oracle: Pubkey
 - usdc_mint: Pubkey
@@ -17,7 +17,7 @@ Defines canonical account schemas and field semantics for Config/Market/OutcomeP
 - claim_window_secs: i64
 - token_program: Pubkey
 
-## Market (draft)
+## Market
 - market_id: [u8;32]
 - event_id: [u8;32]
 - lock_timestamp: i64
@@ -32,12 +32,12 @@ Defines canonical account schemas and field semantics for Config/Market/OutcomeP
 - market_type: enum
 - rules_version: u16
 
-## OutcomePool (draft)
+## OutcomePool
 - market: Pubkey
 - outcome_id: u8
 - pool_amount: u64
 
-## Position (draft)
+## Position
 - market: Pubkey
 - user: Pubkey
 - outcome_id: u8


### PR DESCRIPTION
Locks remaining top-level spec documents now that pivot semantics and test/harness foundation are stable.

## What changed
- Marked as LOCKED:
  - `SPEC_PROTOCOL.md` (v1.0.4)
  - `SPEC_ACCOUNTS.md` (v1.0.2)
  - `SPEC_CANONICAL.md` (v1.0.1)
  - `SPEC_STATE_SCHEMA.md` (v1.0.1)
  - `SPEC_INSTRUCTIONS/INDEX.md` (v1.0.6)
- Normalized `claim_voided` status in instruction index table to `LOCKED` for consistency with locked instruction spec file.
- Removed lingering "(draft)" section labels inside state schema headings.

## Why
Governance consistency before #59 (`initialize`) implementation: no remaining top-level spec docs should be DRAFT while instruction coding starts.

## File-by-file summary
1. `SPEC_PROTOCOL.md`
   - status set to LOCKED; version bumped.
   - Why: protocol semantics have stabilized through #54–#58.

2. `SPEC_ACCOUNTS.md`
   - status set to LOCKED; version bumped.
   - Why: account contract should be immutable baseline for instruction implementation.

3. `SPEC_CANONICAL.md`
   - status set to LOCKED; version bumped.
   - Why: canonical ID derivation now covered by unit vectors and should be fixed.

4. `SPEC_STATE_SCHEMA.md`
   - status set to LOCKED; version bumped; removed draft section labels.
   - Why: schema language should reflect finalized contract semantics.

5. `SPEC_INSTRUCTIONS/INDEX.md`
   - status set to LOCKED; version bumped; `claim_voided` row status corrected to LOCKED.
   - Why: inventory/status consistency and governance clarity.

Validation:
- `node scripts/spec_gate_check.js` ✅

