### PR TITLE
CI: require full discovered tests on PRs

### DIFF
--- a/.github/workflows/full-tests.yml
+++ b/.github/workflows/full-tests.yml
@@ -1,0 +1,18 @@
+name: full-tests
+on:
+  pull_request:
+  push:
+    branches: [ main ]
+
+jobs:
+  full-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - name: Install deps (deterministic)
+        run: npm ci --ignore-scripts
+      - name: Run all discovered tests
+        run: HARNESS_NOW_SECS=1800000000 npm run test:all

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "build": "turbo build",
     "lint": "turbo lint",
     "typecheck": "turbo typecheck",
-    "test": "node tests/instructions/initialize.spec.js && node tests/instructions/initialize.conformance.spec.js && node tests/harness/smoke.spec.js && node tests/unit/canonical_ids.spec.js && node tests/unit/timestamp_rules.spec.js && node tests/unit/math.spec.js",
+    "test": "npm run test:all",
     "clean": "turbo clean && git clean -xfd -e node_modules",
     "format": "prettier . --write",
     "format:check": "prettier . --check",
@@ -18,7 +18,8 @@
     "test:initialize:conformance": "node tests/instructions/initialize.conformance.spec.js",
     "test:harness": "node tests/harness/smoke.spec.js",
     "test:harness:deterministic": "HARNESS_NOW_SECS=1800000000 node tests/harness/smoke.spec.js",
-    "test:unit": "node tests/unit/canonical_ids.spec.js && node tests/unit/timestamp_rules.spec.js && node tests/unit/math.spec.js"
+    "test:unit": "node tests/unit/canonical_ids.spec.js && node tests/unit/timestamp_rules.spec.js && node tests/unit/math.spec.js",
+    "test:all": "node scripts/run_all_tests.js"
   },
   "devDependencies": {
     "turbo": "^2.5.0",

--- a/scripts/run_all_tests.js
+++ b/scripts/run_all_tests.js
@@ -1,0 +1,32 @@
+const fs = require('fs');
+const path = require('path');
+const { spawnSync } = require('child_process');
+
+function collectSpecFiles(dir, acc = []) {
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const p = path.join(dir, entry.name);
+    if (entry.isDirectory()) collectSpecFiles(p, acc);
+    else if (entry.isFile() && entry.name.endsWith('.spec.js')) acc.push(p);
+  }
+  return acc;
+}
+
+const root = process.cwd();
+const testsDir = path.join(root, 'tests');
+const specs = collectSpecFiles(testsDir).sort();
+
+if (specs.length === 0) {
+  console.error('No test spec files found under tests/**/*.spec.js');
+  process.exit(1);
+}
+
+for (const file of specs) {
+  console.log(`\n==> ${path.relative(root, file)}`);
+  const r = spawnSync(process.execPath, [file], {
+    stdio: 'inherit',
+    env: { ...process.env, HARNESS_NOW_SECS: process.env.HARNESS_NOW_SECS || '1800000000' },
+  });
+  if (r.status !== 0) process.exit(r.status || 1);
+}
+
+console.log(`\nAll ${specs.length} test files passed.`);


### PR DESCRIPTION
Adds a full-tests workflow that runs all test files discovered under tests/**/*.spec.js on every PR/push.\n\nAlso adds scripts/run_all_tests.js and sets npm test to use this discovery runner, so any newly added spec test is automatically executed in CI before merge.