### PR TITLE
Issue #105: Anchor wiring for claim/sweep/cancel terminal flows

### DIFF
--- a/programs/pitstop/src/anchor_accounts.rs
+++ b/programs/pitstop/src/anchor_accounts.rs
@@ -557,11 +557,7 @@ pub struct SweepRemaining<'info> {
     #[account(mut)]
     pub authority: Signer<'info>,
 
-    #[account(
-        seeds = [CONFIG_SEED],
-        bump,
-        constraint = config.treasury == treasury.key() @ crate::anchor_errors::PitStopAnchorError::InvalidTreasuryOwner,
-    )]
+    #[account(seeds = [CONFIG_SEED], bump)]
     pub config: Account<'info, Config>,
 
     #[account(

--- a/programs/pitstop/src/anchor_accounts.rs
+++ b/programs/pitstop/src/anchor_accounts.rs
@@ -442,3 +442,132 @@ pub struct VoidMarket<'info> {
     #[account(mut)]
     pub market: Account<'info, Market>,
 }
+
+#[derive(AnchorSerialize, AnchorDeserialize, Clone, Debug)]
+pub struct ClaimResolvedArgs {
+    pub outcome_id: u8,
+}
+
+/// Accounts for `claim_resolved`.
+#[derive(Accounts)]
+#[instruction(args: ClaimResolvedArgs)]
+pub struct ClaimResolved<'info> {
+    #[account(mut)]
+    pub user: Signer<'info>,
+
+    #[account(seeds = [CONFIG_SEED], bump)]
+    pub config: Account<'info, Config>,
+
+    #[account(mut)]
+    pub market: Account<'info, Market>,
+
+    #[account(
+        mut,
+        seeds = [POSITION_SEED, market.key().as_ref(), user.key().as_ref(), &[args.outcome_id]],
+        bump
+    )]
+    pub position: Account<'info, Position>,
+
+    /// CHECK: validated/decoded in handler so missing/wrong relation can map to OutcomeMismatch.
+    #[account(mut)]
+    pub outcome_pool: AccountInfo<'info>,
+
+    #[account(mut)]
+    pub user_usdc: InterfaceAccount<'info, TokenAccount>,
+
+    #[account(mut)]
+    pub vault: InterfaceAccount<'info, TokenAccount>,
+
+    pub usdc_mint: InterfaceAccount<'info, Mint>,
+
+    pub token_program: Interface<'info, TokenInterface>,
+}
+
+#[derive(AnchorSerialize, AnchorDeserialize, Clone, Debug)]
+pub struct ClaimVoidedArgs {
+    pub outcome_id: u8,
+}
+
+/// Accounts for `claim_voided`.
+#[derive(Accounts)]
+#[instruction(args: ClaimVoidedArgs)]
+pub struct ClaimVoided<'info> {
+    #[account(mut)]
+    pub user: Signer<'info>,
+
+    #[account(seeds = [CONFIG_SEED], bump)]
+    pub config: Account<'info, Config>,
+
+    #[account(mut)]
+    pub market: Account<'info, Market>,
+
+    #[account(
+        mut,
+        seeds = [POSITION_SEED, market.key().as_ref(), user.key().as_ref(), &[args.outcome_id]],
+        bump
+    )]
+    pub position: Account<'info, Position>,
+
+    #[account(mut)]
+    pub user_usdc: InterfaceAccount<'info, TokenAccount>,
+
+    #[account(mut)]
+    pub vault: InterfaceAccount<'info, TokenAccount>,
+
+    pub usdc_mint: InterfaceAccount<'info, Mint>,
+
+    pub token_program: Interface<'info, TokenInterface>,
+}
+
+/// Accounts for `sweep_remaining`.
+#[derive(Accounts)]
+pub struct SweepRemaining<'info> {
+    #[account(mut)]
+    pub authority: Signer<'info>,
+
+    #[account(
+        seeds = [CONFIG_SEED],
+        bump,
+        constraint = config.treasury == treasury.key() @ crate::anchor_errors::PitStopAnchorError::InvalidTreasuryOwner,
+    )]
+    pub config: Account<'info, Config>,
+
+    #[account(mut)]
+    pub market: Account<'info, Market>,
+
+    #[account(mut)]
+    pub vault: InterfaceAccount<'info, TokenAccount>,
+
+    #[account(mut)]
+    pub treasury: InterfaceAccount<'info, TokenAccount>,
+
+    /// CHECK: destination for recovered rent from vault close.
+    #[account(mut)]
+    pub close_destination: SystemAccount<'info>,
+
+    pub usdc_mint: InterfaceAccount<'info, Mint>,
+
+    pub token_program: Interface<'info, TokenInterface>,
+}
+
+/// Accounts for `cancel_market`.
+#[derive(Accounts)]
+pub struct CancelMarket<'info> {
+    #[account(mut)]
+    pub authority: Signer<'info>,
+
+    #[account(seeds = [CONFIG_SEED], bump)]
+    pub config: Account<'info, Config>,
+
+    #[account(mut)]
+    pub market: Account<'info, Market>,
+
+    #[account(mut)]
+    pub vault: InterfaceAccount<'info, TokenAccount>,
+
+    /// CHECK: destination for recovered rent from vault close.
+    #[account(mut)]
+    pub close_destination: SystemAccount<'info>,
+
+    pub token_program: Interface<'info, TokenInterface>,
+}

--- a/programs/pitstop/src/anchor_accounts.rs
+++ b/programs/pitstop/src/anchor_accounts.rs
@@ -306,7 +306,11 @@ pub struct AddOutcome<'info> {
     #[account(seeds = [CONFIG_SEED], bump)]
     pub config: Account<'info, Config>,
 
-    #[account(mut)]
+    #[account(
+        mut,
+        seeds = [MARKET_SEED, market.market_id.as_ref()],
+        bump
+    )]
     pub market: Account<'info, Market>,
 
     #[account(
@@ -333,7 +337,11 @@ pub struct FinalizeSeeding<'info> {
     #[account(seeds = [CONFIG_SEED], bump)]
     pub config: Account<'info, Config>,
 
-    #[account(mut)]
+    #[account(
+        mut,
+        seeds = [MARKET_SEED, market.market_id.as_ref()],
+        bump
+    )]
     pub market: Account<'info, Market>,
 }
 
@@ -358,7 +366,11 @@ pub struct PlaceBet<'info> {
     #[account(seeds = [CONFIG_SEED], bump)]
     pub config: Account<'info, Config>,
 
-    #[account(mut)]
+    #[account(
+        mut,
+        seeds = [MARKET_SEED, market.market_id.as_ref()],
+        bump
+    )]
     pub market: Account<'info, Market>,
 
     /// CHECK: validated/decoded in handler so missing/wrong relation can map to OutcomeMismatch.
@@ -396,7 +408,11 @@ pub struct LockMarket<'info> {
     #[account(seeds = [CONFIG_SEED], bump)]
     pub config: Account<'info, Config>,
 
-    #[account(mut)]
+    #[account(
+        mut,
+        seeds = [MARKET_SEED, market.market_id.as_ref()],
+        bump
+    )]
     pub market: Account<'info, Market>,
 }
 
@@ -416,7 +432,11 @@ pub struct ResolveMarket<'info> {
     #[account(seeds = [CONFIG_SEED], bump)]
     pub config: Account<'info, Config>,
 
-    #[account(mut)]
+    #[account(
+        mut,
+        seeds = [MARKET_SEED, market.market_id.as_ref()],
+        bump
+    )]
     pub market: Account<'info, Market>,
 
     /// CHECK: validated/decoded in handler so missing/wrong relation can map to OutcomeMismatch.
@@ -439,7 +459,11 @@ pub struct VoidMarket<'info> {
     #[account(seeds = [CONFIG_SEED], bump)]
     pub config: Account<'info, Config>,
 
-    #[account(mut)]
+    #[account(
+        mut,
+        seeds = [MARKET_SEED, market.market_id.as_ref()],
+        bump
+    )]
     pub market: Account<'info, Market>,
 }
 
@@ -458,7 +482,11 @@ pub struct ClaimResolved<'info> {
     #[account(seeds = [CONFIG_SEED], bump)]
     pub config: Account<'info, Config>,
 
-    #[account(mut)]
+    #[account(
+        mut,
+        seeds = [MARKET_SEED, market.market_id.as_ref()],
+        bump
+    )]
     pub market: Account<'info, Market>,
 
     #[account(
@@ -498,7 +526,11 @@ pub struct ClaimVoided<'info> {
     #[account(seeds = [CONFIG_SEED], bump)]
     pub config: Account<'info, Config>,
 
-    #[account(mut)]
+    #[account(
+        mut,
+        seeds = [MARKET_SEED, market.market_id.as_ref()],
+        bump
+    )]
     pub market: Account<'info, Market>,
 
     #[account(
@@ -532,7 +564,11 @@ pub struct SweepRemaining<'info> {
     )]
     pub config: Account<'info, Config>,
 
-    #[account(mut)]
+    #[account(
+        mut,
+        seeds = [MARKET_SEED, market.market_id.as_ref()],
+        bump
+    )]
     pub market: Account<'info, Market>,
 
     #[account(mut)]
@@ -559,7 +595,11 @@ pub struct CancelMarket<'info> {
     #[account(seeds = [CONFIG_SEED], bump)]
     pub config: Account<'info, Config>,
 
-    #[account(mut)]
+    #[account(
+        mut,
+        seeds = [MARKET_SEED, market.market_id.as_ref()],
+        bump
+    )]
     pub market: Account<'info, Market>,
 
     #[account(mut)]

--- a/programs/pitstop/src/anchor_events.rs
+++ b/programs/pitstop/src/anchor_events.rs
@@ -67,3 +67,26 @@ pub struct MarketVoided {
     pub payload_hash: [u8; 32],
     pub resolution_timestamp: i64,
 }
+
+#[event]
+pub struct Claimed {
+    pub market: Pubkey,
+    pub user: Pubkey,
+    pub outcome_id: u8,
+    pub payout: u64,
+    pub claimed_at: i64,
+}
+
+#[event]
+pub struct MarketSweptEvent {
+    pub market: Pubkey,
+    pub amount: u64,
+    pub to_treasury: Pubkey,
+    pub timestamp: i64,
+}
+
+#[event]
+pub struct MarketCancelled {
+    pub market: Pubkey,
+    pub timestamp: i64,
+}

--- a/programs/pitstop/src/lib.rs
+++ b/programs/pitstop/src/lib.rs
@@ -95,15 +95,21 @@ mod handlers {
         Ok(Clock::get()?.unix_timestamp)
     }
 
+    fn required_token_program_pubkey() -> Result<Pubkey> {
+        Pubkey::from_str(constants::REQUIRED_TOKEN_PROGRAM)
+            .map_err(|_| error!(PitStopAnchorError::InvalidTokenProgram))
+    }
+
     pub fn initialize(ctx: Context<Initialize>, args: InitializeArgs) -> Result<()> {
         // Layer 1 validation (Anchor handler level):
         // perform explicit protocol-mapped guards before invoking parity logic.
         //
         // We intentionally map to PitStopAnchorError here so callers see the same
         // deterministic error taxonomy expected by LOCKED specs.
+        let required_token_program = required_token_program_pubkey()?;
         require_keys_eq!(
             ctx.accounts.token_program.key(),
-            Pubkey::from_str(constants::REQUIRED_TOKEN_PROGRAM).unwrap(),
+            required_token_program,
             PitStopAnchorError::InvalidTokenProgram
         );
 
@@ -154,7 +160,7 @@ mod handlers {
         config.max_total_pool_per_market = cfg.max_total_pool_per_market;
         config.max_bet_per_user_per_market = cfg.max_bet_per_user_per_market;
         config.claim_window_secs = cfg.claim_window_secs;
-        config.token_program = Pubkey::from_str(constants::REQUIRED_TOKEN_PROGRAM).unwrap();
+        config.token_program = required_token_program;
 
         // Event emission:
         // emit after successful state write so off-chain observers see committed transitions.

--- a/programs/pitstop/src/lib.rs
+++ b/programs/pitstop/src/lib.rs
@@ -60,13 +60,31 @@ pub mod pitstop {
     pub fn void_market(ctx: Context<VoidMarket>, args: VoidMarketArgs) -> Result<()> {
         handlers::void_market(ctx, args)
     }
+
+    pub fn claim_resolved(ctx: Context<ClaimResolved>, args: ClaimResolvedArgs) -> Result<()> {
+        handlers::claim_resolved(ctx, args)
+    }
+
+    pub fn claim_voided(ctx: Context<ClaimVoided>, args: ClaimVoidedArgs) -> Result<()> {
+        handlers::claim_voided(ctx, args)
+    }
+
+    pub fn sweep_remaining(ctx: Context<SweepRemaining>) -> Result<()> {
+        handlers::sweep_remaining(ctx)
+    }
+
+    pub fn cancel_market(ctx: Context<CancelMarket>) -> Result<()> {
+        handlers::cancel_market(ctx)
+    }
 }
 
 mod handlers {
     use super::*;
     use std::str::FromStr;
 
-    use anchor_spl::token_interface::{Mint, TokenAccount};
+    use anchor_spl::token_interface::{
+        close_account, transfer_checked, CloseAccount, Mint, TokenAccount, TransferChecked,
+    };
 
     /// Single clock read helper so all handlers use the same on-chain time source.
     ///
@@ -513,6 +531,369 @@ mod handlers {
             market: ctx.accounts.market.key(),
             payload_hash: evt.payload_hash,
             resolution_timestamp: evt.resolution_timestamp,
+        });
+
+        Ok(())
+    }
+
+    pub fn claim_resolved(ctx: Context<ClaimResolved>, args: ClaimResolvedArgs) -> Result<()> {
+        require_keys_eq!(
+            ctx.accounts.token_program.key(),
+            ctx.accounts.config.token_program,
+            PitStopAnchorError::InvalidTokenProgram
+        );
+        require_keys_eq!(
+            ctx.accounts.usdc_mint.key(),
+            ctx.accounts.config.usdc_mint,
+            PitStopAnchorError::InvalidTreasuryMint
+        );
+        require_keys_eq!(
+            ctx.accounts.vault.key(),
+            ctx.accounts.market.vault,
+            PitStopAnchorError::OutcomeMismatch
+        );
+        require_keys_eq!(
+            ctx.accounts.user_usdc.mint,
+            ctx.accounts.usdc_mint.key(),
+            PitStopAnchorError::InvalidTreasuryMint
+        );
+        require_keys_eq!(
+            ctx.accounts.user_usdc.owner,
+            ctx.accounts.user.key(),
+            PitStopAnchorError::Unauthorized
+        );
+
+        let expected_pool = Pubkey::find_program_address(
+            &[OUTCOME_SEED, ctx.accounts.market.key().as_ref(), &[args.outcome_id]],
+            &crate::id(),
+        )
+        .0;
+        if ctx.accounts.outcome_pool.key() != expected_pool {
+            return Err(error!(PitStopAnchorError::OutcomeMismatch));
+        }
+        if ctx.accounts.outcome_pool.owner != &crate::id() {
+            return Err(error!(PitStopAnchorError::OutcomeMismatch));
+        }
+        let outcome_pool: OutcomePool = {
+            let data_ref = ctx.accounts.outcome_pool.try_borrow_data()?;
+            if data_ref.is_empty() {
+                return Err(error!(PitStopAnchorError::OutcomeMismatch));
+            }
+            let mut slice: &[u8] = &data_ref;
+            OutcomePool::try_deserialize(&mut slice)
+                .map_err(|_| error!(PitStopAnchorError::OutcomeMismatch))?
+        };
+        if outcome_pool.market != ctx.accounts.market.key() || outcome_pool.outcome_id != args.outcome_id {
+            return Err(error!(PitStopAnchorError::OutcomeMismatch));
+        }
+
+        let now_ts = clock_unix_timestamp()?;
+        let market_state = ctx.accounts.market.to_parity();
+        let input = instructions::claim_resolved::ClaimResolvedInput {
+            market: ctx.accounts.market.key().to_string(),
+            user: ctx.accounts.user.key().to_string(),
+            market_status: market_state.status,
+            now_ts,
+            resolution_timestamp: market_state.resolution_timestamp,
+            claim_window_secs: ctx.accounts.config.claim_window_secs,
+            fee_bps: ctx.accounts.config.fee_bps,
+            resolved_outcome: market_state.resolved_outcome,
+            outcome_id: args.outcome_id,
+            position_claimed: ctx.accounts.position.claimed,
+            position_amount: ctx.accounts.position.amount,
+            outcome_pool_exists: true,
+            outcome_pool_market: outcome_pool.market.to_string(),
+            outcome_pool_outcome_id: outcome_pool.outcome_id,
+            outcome_pool_amount: outcome_pool.pool_amount,
+            vault_amount: ctx.accounts.vault.amount,
+            user_usdc_amount: ctx.accounts.user_usdc.amount,
+            market_state,
+            outcome_pool_state: crate::state::OutcomePool {
+                market: outcome_pool.market.to_string(),
+                outcome_id: outcome_pool.outcome_id,
+                pool_amount: outcome_pool.pool_amount,
+            },
+            position_state: ctx.accounts.position.to_parity(),
+        };
+
+        let (new_pos, _new_vault_amount, _new_user_amount, evt) =
+            instructions::claim_resolved::claim_resolved(input).map_err(PitStopAnchorError::from)?;
+
+        if evt.payout > 0 {
+            let cpi_accounts = TransferChecked {
+                from: ctx.accounts.vault.to_account_info(),
+                mint: ctx.accounts.usdc_mint.to_account_info(),
+                to: ctx.accounts.user_usdc.to_account_info(),
+                authority: ctx.accounts.market.to_account_info(),
+            };
+            let (_market_pda, market_bump) = Pubkey::find_program_address(
+                &[MARKET_SEED, ctx.accounts.market.market_id.as_ref()],
+                &crate::id(),
+            );
+            let signer_seeds: &[&[u8]] = &[
+                MARKET_SEED,
+                ctx.accounts.market.market_id.as_ref(),
+                &[market_bump],
+            ];
+            let signer = &[signer_seeds];
+            let cpi_ctx = CpiContext::new_with_signer(
+                ctx.accounts.token_program.to_account_info(),
+                cpi_accounts,
+                signer,
+            );
+            transfer_checked(cpi_ctx, evt.payout, ctx.accounts.usdc_mint.decimals)?;
+        }
+
+        ctx.accounts.position.apply_parity(&new_pos);
+
+        emit!(anchor_events::Claimed {
+            market: ctx.accounts.market.key(),
+            user: ctx.accounts.user.key(),
+            outcome_id: evt.outcome_id,
+            payout: evt.payout,
+            claimed_at: evt.claimed_at,
+        });
+
+        Ok(())
+    }
+
+    pub fn claim_voided(ctx: Context<ClaimVoided>, args: ClaimVoidedArgs) -> Result<()> {
+        require_keys_eq!(
+            ctx.accounts.token_program.key(),
+            ctx.accounts.config.token_program,
+            PitStopAnchorError::InvalidTokenProgram
+        );
+        require_keys_eq!(
+            ctx.accounts.usdc_mint.key(),
+            ctx.accounts.config.usdc_mint,
+            PitStopAnchorError::InvalidTreasuryMint
+        );
+        require_keys_eq!(
+            ctx.accounts.vault.key(),
+            ctx.accounts.market.vault,
+            PitStopAnchorError::OutcomeMismatch
+        );
+        require_keys_eq!(
+            ctx.accounts.user_usdc.mint,
+            ctx.accounts.usdc_mint.key(),
+            PitStopAnchorError::InvalidTreasuryMint
+        );
+        require_keys_eq!(
+            ctx.accounts.user_usdc.owner,
+            ctx.accounts.user.key(),
+            PitStopAnchorError::Unauthorized
+        );
+
+        let now_ts = clock_unix_timestamp()?;
+        let input = instructions::claim_voided::ClaimVoidedInput {
+            market: ctx.accounts.market.key().to_string(),
+            user: ctx.accounts.user.key().to_string(),
+            market_status: ctx.accounts.market.to_parity().status,
+            resolution_timestamp: ctx.accounts.market.resolution_timestamp,
+            claim_window_secs: ctx.accounts.config.claim_window_secs,
+            now_ts,
+            outcome_id: args.outcome_id,
+            user_usdc_amount: ctx.accounts.user_usdc.amount,
+            vault_amount: ctx.accounts.vault.amount,
+            position_state: ctx.accounts.position.to_parity(),
+        };
+
+        let (new_pos, _new_user_amount, _new_vault_amount, evt) =
+            instructions::claim_voided::claim_voided(input).map_err(PitStopAnchorError::from)?;
+
+        if evt.payout > 0 {
+            let cpi_accounts = TransferChecked {
+                from: ctx.accounts.vault.to_account_info(),
+                mint: ctx.accounts.usdc_mint.to_account_info(),
+                to: ctx.accounts.user_usdc.to_account_info(),
+                authority: ctx.accounts.market.to_account_info(),
+            };
+            let (_market_pda, market_bump) = Pubkey::find_program_address(
+                &[MARKET_SEED, ctx.accounts.market.market_id.as_ref()],
+                &crate::id(),
+            );
+            let signer_seeds: &[&[u8]] = &[
+                MARKET_SEED,
+                ctx.accounts.market.market_id.as_ref(),
+                &[market_bump],
+            ];
+            let signer = &[signer_seeds];
+            let cpi_ctx = CpiContext::new_with_signer(
+                ctx.accounts.token_program.to_account_info(),
+                cpi_accounts,
+                signer,
+            );
+            transfer_checked(cpi_ctx, evt.payout, ctx.accounts.usdc_mint.decimals)?;
+        }
+
+        ctx.accounts.position.apply_parity(&new_pos);
+
+        emit!(anchor_events::Claimed {
+            market: ctx.accounts.market.key(),
+            user: ctx.accounts.user.key(),
+            outcome_id: evt.outcome_id,
+            payout: evt.payout,
+            claimed_at: evt.claimed_at,
+        });
+
+        Ok(())
+    }
+
+    pub fn sweep_remaining(ctx: Context<SweepRemaining>) -> Result<()> {
+        require_keys_eq!(
+            ctx.accounts.token_program.key(),
+            ctx.accounts.config.token_program,
+            PitStopAnchorError::InvalidTokenProgram
+        );
+        require_keys_eq!(
+            ctx.accounts.usdc_mint.key(),
+            ctx.accounts.config.usdc_mint,
+            PitStopAnchorError::InvalidTreasuryMint
+        );
+        require_keys_eq!(
+            ctx.accounts.treasury.mint,
+            ctx.accounts.usdc_mint.key(),
+            PitStopAnchorError::InvalidTreasuryMint
+        );
+        require_keys_eq!(
+            ctx.accounts.treasury.owner,
+            ctx.accounts.config.treasury_authority,
+            PitStopAnchorError::InvalidTreasuryOwner
+        );
+        require_keys_eq!(
+            ctx.accounts.vault.key(),
+            ctx.accounts.market.vault,
+            PitStopAnchorError::OutcomeMismatch
+        );
+
+        let now_ts = clock_unix_timestamp()?;
+        let market_state = ctx.accounts.market.to_parity();
+        let input = instructions::sweep_remaining::SweepRemainingInput {
+            authority: ctx.accounts.authority.key().to_string(),
+            config_authority: ctx.accounts.config.authority.to_string(),
+            market: ctx.accounts.market.key().to_string(),
+            now_ts,
+            claim_window_secs: ctx.accounts.config.claim_window_secs,
+            token_program: ctx.accounts.token_program.key().to_string(),
+            treasury: ctx.accounts.treasury.key().to_string(),
+            config_treasury: ctx.accounts.config.treasury.to_string(),
+            treasury_mint: ctx.accounts.treasury.mint.to_string(),
+            usdc_mint: ctx.accounts.usdc_mint.key().to_string(),
+            treasury_owner: ctx.accounts.treasury.owner.to_string(),
+            treasury_authority: ctx.accounts.config.treasury_authority.to_string(),
+            vault_amount: ctx.accounts.vault.amount,
+            treasury_amount: ctx.accounts.treasury.amount,
+            market_state,
+        };
+
+        let (new_market, _new_treasury_amount, swept_amount, _vault_closed, _vault_exists, _used_seeds, evt) =
+            instructions::sweep_remaining::sweep_remaining(input).map_err(PitStopAnchorError::from)?;
+
+        let (_market_pda, market_bump) = Pubkey::find_program_address(
+            &[MARKET_SEED, ctx.accounts.market.market_id.as_ref()],
+            &crate::id(),
+        );
+        let signer_seeds: &[&[u8]] = &[
+            MARKET_SEED,
+            ctx.accounts.market.market_id.as_ref(),
+            &[market_bump],
+        ];
+        let signer = &[signer_seeds];
+
+        if swept_amount > 0 {
+            let transfer_accounts = TransferChecked {
+                from: ctx.accounts.vault.to_account_info(),
+                mint: ctx.accounts.usdc_mint.to_account_info(),
+                to: ctx.accounts.treasury.to_account_info(),
+                authority: ctx.accounts.market.to_account_info(),
+            };
+            let transfer_ctx = CpiContext::new_with_signer(
+                ctx.accounts.token_program.to_account_info(),
+                transfer_accounts,
+                signer,
+            );
+            transfer_checked(transfer_ctx, swept_amount, ctx.accounts.usdc_mint.decimals)?;
+        }
+
+        let close_accounts = CloseAccount {
+            account: ctx.accounts.vault.to_account_info(),
+            destination: ctx.accounts.close_destination.to_account_info(),
+            authority: ctx.accounts.market.to_account_info(),
+        };
+        let close_ctx = CpiContext::new_with_signer(
+            ctx.accounts.token_program.to_account_info(),
+            close_accounts,
+            signer,
+        );
+        close_account(close_ctx)?;
+
+        ctx.accounts.market.apply_parity(&new_market);
+
+        emit!(anchor_events::MarketSweptEvent {
+            market: ctx.accounts.market.key(),
+            amount: evt.amount,
+            to_treasury: ctx.accounts.treasury.key(),
+            timestamp: evt.timestamp,
+        });
+
+        Ok(())
+    }
+
+    pub fn cancel_market(ctx: Context<CancelMarket>) -> Result<()> {
+        require_keys_eq!(
+            ctx.accounts.token_program.key(),
+            ctx.accounts.config.token_program,
+            PitStopAnchorError::InvalidTokenProgram
+        );
+        require_keys_eq!(
+            ctx.accounts.vault.key(),
+            ctx.accounts.market.vault,
+            PitStopAnchorError::OutcomeMismatch
+        );
+
+        let now_ts = clock_unix_timestamp()?;
+        let input = instructions::cancel_market::CancelMarketInput {
+            authority: ctx.accounts.authority.key().to_string(),
+            config_authority: ctx.accounts.config.authority.to_string(),
+            close_destination: ctx.accounts.close_destination.key().to_string(),
+            market: ctx.accounts.market.key().to_string(),
+            market_status: ctx.accounts.market.to_parity().status,
+            now_ts,
+            lock_timestamp: ctx.accounts.market.lock_timestamp,
+            market_state: ctx.accounts.market.to_parity(),
+            vault_amount: ctx.accounts.vault.amount,
+        };
+
+        let (new_market, evt) =
+            instructions::cancel_market::cancel_market(input).map_err(PitStopAnchorError::from)?;
+
+        let (_market_pda, market_bump) = Pubkey::find_program_address(
+            &[MARKET_SEED, ctx.accounts.market.market_id.as_ref()],
+            &crate::id(),
+        );
+        let signer_seeds: &[&[u8]] = &[
+            MARKET_SEED,
+            ctx.accounts.market.market_id.as_ref(),
+            &[market_bump],
+        ];
+        let signer = &[signer_seeds];
+        let close_accounts = CloseAccount {
+            account: ctx.accounts.vault.to_account_info(),
+            destination: ctx.accounts.close_destination.to_account_info(),
+            authority: ctx.accounts.market.to_account_info(),
+        };
+        let close_ctx = CpiContext::new_with_signer(
+            ctx.accounts.token_program.to_account_info(),
+            close_accounts,
+            signer,
+        );
+        close_account(close_ctx)?;
+
+        ctx.accounts.market.apply_parity(&new_market);
+
+        emit!(anchor_events::MarketCancelled {
+            market: ctx.accounts.market.key(),
+            timestamp: evt.timestamp,
         });
 
         Ok(())

--- a/programs/pitstop/src/lib.rs
+++ b/programs/pitstop/src/lib.rs
@@ -330,7 +330,7 @@ mod handlers {
 
         // Load/validate outcome_pool with spec-mapped error behavior.
         let expected_pool = Pubkey::find_program_address(
-            &[b"outcome", ctx.accounts.market.key().as_ref(), &[args.outcome_id]],
+            &[OUTCOME_SEED, ctx.accounts.market.key().as_ref(), &[args.outcome_id]],
             &crate::id(),
         )
         .0;
@@ -461,7 +461,7 @@ mod handlers {
         let now_ts = clock_unix_timestamp()?;
 
         let expected_pool = Pubkey::find_program_address(
-            &[b"outcome", ctx.accounts.market.key().as_ref(), &[args.winning_outcome_id]],
+            &[OUTCOME_SEED, ctx.accounts.market.key().as_ref(), &[args.winning_outcome_id]],
             &crate::id(),
         )
         .0;

--- a/programs/pitstop/tests/anchor_wire_105.rs
+++ b/programs/pitstop/tests/anchor_wire_105.rs
@@ -1,0 +1,510 @@
+use anchor_lang::{prelude::*, AccountDeserialize, InstructionData, ToAccountMetas};
+use solana_program_test::*;
+use solana_sdk::{
+    entrypoint::ProgramResult,
+    program_pack::Pack,
+    signature::{Keypair, Signer},
+    transaction::Transaction,
+};
+
+use pitstop::{self, anchor_accounts::*};
+
+fn pitstop_entry<'a, 'b, 'c, 'd>(
+    program_id: &'a Pubkey,
+    accounts: &'b [AccountInfo<'c>],
+    data: &'d [u8],
+) -> ProgramResult {
+    let accounts: &'c [AccountInfo<'c>] = unsafe { std::mem::transmute(accounts) };
+    pitstop::entry(program_id, accounts, data)
+}
+
+fn program_test() -> ProgramTest {
+    ProgramTest::new("pitstop", pitstop::id(), processor!(pitstop_entry))
+}
+
+async fn fund(ctx: &mut ProgramTestContext, kp: &Keypair, lamports: u64) {
+    let tx = Transaction::new_signed_with_payer(
+        &[solana_sdk::system_instruction::transfer(
+            &ctx.payer.pubkey(),
+            &kp.pubkey(),
+            lamports,
+        )],
+        Some(&ctx.payer.pubkey()),
+        &[&ctx.payer],
+        ctx.last_blockhash,
+    );
+    ctx.banks_client.process_transaction(tx).await.unwrap();
+}
+
+async fn create_mint(ctx: &mut ProgramTestContext, mint: &Keypair, mint_authority: &Pubkey) {
+    let rent = ctx.banks_client.get_rent().await.unwrap();
+    let space = spl_token::state::Mint::LEN;
+    let lamports = rent.minimum_balance(space);
+
+    let create = solana_sdk::system_instruction::create_account(
+        &ctx.payer.pubkey(),
+        &mint.pubkey(),
+        lamports,
+        space as u64,
+        &spl_token::id(),
+    );
+    let init = spl_token::instruction::initialize_mint(
+        &spl_token::id(),
+        &mint.pubkey(),
+        mint_authority,
+        None,
+        6,
+    )
+    .unwrap();
+
+    let tx = Transaction::new_signed_with_payer(
+        &[create, init],
+        Some(&ctx.payer.pubkey()),
+        &[&ctx.payer, mint],
+        ctx.last_blockhash,
+    );
+    ctx.banks_client.process_transaction(tx).await.unwrap();
+}
+
+async fn create_token_account(
+    ctx: &mut ProgramTestContext,
+    acct: &Keypair,
+    mint: &Pubkey,
+    owner: &Pubkey,
+) {
+    let rent = ctx.banks_client.get_rent().await.unwrap();
+    let space = spl_token::state::Account::LEN;
+    let lamports = rent.minimum_balance(space);
+
+    let create = solana_sdk::system_instruction::create_account(
+        &ctx.payer.pubkey(),
+        &acct.pubkey(),
+        lamports,
+        space as u64,
+        &spl_token::id(),
+    );
+    let init = spl_token::instruction::initialize_account(
+        &spl_token::id(),
+        &acct.pubkey(),
+        mint,
+        owner,
+    )
+    .unwrap();
+
+    let tx = Transaction::new_signed_with_payer(
+        &[create, init],
+        Some(&ctx.payer.pubkey()),
+        &[&ctx.payer, acct],
+        ctx.last_blockhash,
+    );
+    ctx.banks_client.process_transaction(tx).await.unwrap();
+}
+
+async fn mint_to(
+    ctx: &mut ProgramTestContext,
+    mint: &Pubkey,
+    mint_authority: &Keypair,
+    to: &Pubkey,
+    amount: u64,
+) {
+    let ix = spl_token::instruction::mint_to(
+        &spl_token::id(),
+        mint,
+        to,
+        &mint_authority.pubkey(),
+        &[],
+        amount,
+    )
+    .unwrap();
+    let tx = Transaction::new_signed_with_payer(
+        &[ix],
+        Some(&ctx.payer.pubkey()),
+        &[&ctx.payer, mint_authority],
+        ctx.last_blockhash,
+    );
+    ctx.banks_client.process_transaction(tx).await.unwrap();
+}
+
+fn canonical_market_id(event_id: [u8; 32], market_type: u8, rules_version: u16) -> [u8; 32] {
+    use sha2::{Digest, Sha256};
+    let mut bytes = [0u8; 35];
+    bytes[0..32].copy_from_slice(&event_id);
+    bytes[32] = market_type;
+    bytes[33..35].copy_from_slice(&rules_version.to_le_bytes());
+    let digest = Sha256::digest(bytes);
+    let mut out = [0u8; 32];
+    out.copy_from_slice(&digest);
+    out
+}
+
+#[tokio::test]
+async fn issue_105_anchor_claim_and_sweep_status_guards() {
+    let mut ctx = program_test().start_with_context().await;
+
+    let authority = Keypair::new();
+    let treasury_authority = Keypair::new();
+    let user = Keypair::new();
+    for kp in [&authority, &treasury_authority, &user] {
+        fund(&mut ctx, kp, 2_000_000_000).await;
+    }
+
+    let usdc_mint = Keypair::new();
+    create_mint(&mut ctx, &usdc_mint, &authority.pubkey()).await;
+
+    let treasury = Keypair::new();
+    create_token_account(
+        &mut ctx,
+        &treasury,
+        &usdc_mint.pubkey(),
+        &treasury_authority.pubkey(),
+    )
+    .await;
+
+    let user_usdc = Keypair::new();
+    create_token_account(&mut ctx, &user_usdc, &usdc_mint.pubkey(), &user.pubkey()).await;
+    mint_to(&mut ctx, &usdc_mint.pubkey(), &authority, &user_usdc.pubkey(), 500_000).await;
+
+    let (config_pda, _) = Pubkey::find_program_address(&[CONFIG_SEED], &pitstop::id());
+
+    let ix = solana_sdk::instruction::Instruction {
+        program_id: pitstop::id(),
+        accounts: pitstop::accounts::Initialize {
+            authority: authority.pubkey(),
+            config: config_pda,
+            usdc_mint: usdc_mint.pubkey(),
+            treasury: treasury.pubkey(),
+            token_program: spl_token::id(),
+            system_program: solana_sdk::system_program::id(),
+        }
+        .to_account_metas(None),
+        data: pitstop::instruction::Initialize {
+            args: InitializeArgs {
+                treasury_authority: treasury_authority.pubkey(),
+                max_total_pool_per_market: 1_000_000,
+                max_bet_per_user_per_market: 500_000,
+                claim_window_secs: 3600,
+            },
+        }
+        .data(),
+    };
+    let tx = Transaction::new_signed_with_payer(
+        &[ix],
+        Some(&ctx.payer.pubkey()),
+        &[&ctx.payer, &authority],
+        ctx.last_blockhash,
+    );
+    ctx.banks_client.process_transaction(tx).await.unwrap();
+
+    let event_id = [7u8; 32];
+    let market_type = 0u8;
+    let rules_version = 1u16;
+    let market_id = canonical_market_id(event_id, market_type, rules_version);
+    let (market_pda, _) = Pubkey::find_program_address(&[MARKET_SEED, market_id.as_ref()], &pitstop::id());
+    let vault_ata = spl_associated_token_account::get_associated_token_address_with_program_id(
+        &market_pda,
+        &usdc_mint.pubkey(),
+        &spl_token::id(),
+    );
+
+    let ix = solana_sdk::instruction::Instruction {
+        program_id: pitstop::id(),
+        accounts: pitstop::accounts::CreateMarket {
+            authority: authority.pubkey(),
+            config: config_pda,
+            market: market_pda,
+            vault: vault_ata,
+            usdc_mint: usdc_mint.pubkey(),
+            token_program: spl_token::id(),
+            associated_token_program: spl_associated_token_account::id(),
+            system_program: solana_sdk::system_program::id(),
+        }
+        .to_account_metas(None),
+        data: pitstop::instruction::CreateMarket {
+            args: CreateMarketArgs {
+                market_id,
+                event_id,
+                lock_timestamp: i64::MAX,
+                max_outcomes: 2,
+                market_type,
+                rules_version,
+            },
+        }
+        .data(),
+    };
+    let tx = Transaction::new_signed_with_payer(
+        &[ix],
+        Some(&ctx.payer.pubkey()),
+        &[&ctx.payer, &authority],
+        ctx.last_blockhash,
+    );
+    ctx.banks_client.process_transaction(tx).await.unwrap();
+
+    for outcome_id in [1u8, 2u8] {
+        let (pool_pda, _) = Pubkey::find_program_address(
+            &[OUTCOME_SEED, market_pda.as_ref(), &[outcome_id]],
+            &pitstop::id(),
+        );
+        let ix = solana_sdk::instruction::Instruction {
+            program_id: pitstop::id(),
+            accounts: pitstop::accounts::AddOutcome {
+                authority: authority.pubkey(),
+                config: config_pda,
+                market: market_pda,
+                outcome_pool: pool_pda,
+                system_program: solana_sdk::system_program::id(),
+            }
+            .to_account_metas(None),
+            data: pitstop::instruction::AddOutcome {
+                args: AddOutcomeArgs { outcome_id },
+            }
+            .data(),
+        };
+        let tx = Transaction::new_signed_with_payer(
+            &[ix],
+            Some(&ctx.payer.pubkey()),
+            &[&ctx.payer, &authority],
+            ctx.last_blockhash,
+        );
+        ctx.banks_client.process_transaction(tx).await.unwrap();
+    }
+
+    let ix = solana_sdk::instruction::Instruction {
+        program_id: pitstop::id(),
+        accounts: pitstop::accounts::FinalizeSeeding {
+            authority: authority.pubkey(),
+            config: config_pda,
+            market: market_pda,
+        }
+        .to_account_metas(None),
+        data: pitstop::instruction::FinalizeSeeding {}.data(),
+    };
+    let tx = Transaction::new_signed_with_payer(
+        &[ix],
+        Some(&ctx.payer.pubkey()),
+        &[&ctx.payer, &authority],
+        ctx.last_blockhash,
+    );
+    ctx.banks_client.process_transaction(tx).await.unwrap();
+
+    let outcome_id = 1u8;
+    let (pool_pda, _) = Pubkey::find_program_address(
+        &[OUTCOME_SEED, market_pda.as_ref(), &[outcome_id]],
+        &pitstop::id(),
+    );
+    let (pos_pda, _) = Pubkey::find_program_address(
+        &[POSITION_SEED, market_pda.as_ref(), user.pubkey().as_ref(), &[outcome_id]],
+        &pitstop::id(),
+    );
+
+    let ix = solana_sdk::instruction::Instruction {
+        program_id: pitstop::id(),
+        accounts: pitstop::accounts::PlaceBet {
+            user: user.pubkey(),
+            config: config_pda,
+            market: market_pda,
+            outcome_pool: pool_pda,
+            position: pos_pda,
+            user_usdc: user_usdc.pubkey(),
+            vault: vault_ata,
+            usdc_mint: usdc_mint.pubkey(),
+            token_program: spl_token::id(),
+            system_program: solana_sdk::system_program::id(),
+        }
+        .to_account_metas(None),
+        data: pitstop::instruction::PlaceBet {
+            args: PlaceBetArgs {
+                outcome_id,
+                amount: 100_000,
+            },
+        }
+        .data(),
+    };
+    let tx = Transaction::new_signed_with_payer(
+        &[ix],
+        Some(&ctx.payer.pubkey()),
+        &[&ctx.payer, &user],
+        ctx.last_blockhash,
+    );
+    ctx.banks_client.process_transaction(tx).await.unwrap();
+
+    // market is still Open; claim_resolved and sweep_remaining must fail via status guards.
+    let ix = solana_sdk::instruction::Instruction {
+        program_id: pitstop::id(),
+        accounts: pitstop::accounts::ClaimResolved {
+            user: user.pubkey(),
+            config: config_pda,
+            market: market_pda,
+            position: pos_pda,
+            outcome_pool: pool_pda,
+            user_usdc: user_usdc.pubkey(),
+            vault: vault_ata,
+            usdc_mint: usdc_mint.pubkey(),
+            token_program: spl_token::id(),
+        }
+        .to_account_metas(None),
+        data: pitstop::instruction::ClaimResolved {
+            args: ClaimResolvedArgs { outcome_id },
+        }
+        .data(),
+    };
+    let tx = Transaction::new_signed_with_payer(
+        &[ix],
+        Some(&ctx.payer.pubkey()),
+        &[&ctx.payer, &user],
+        ctx.last_blockhash,
+    );
+    assert!(ctx.banks_client.process_transaction(tx).await.is_err());
+
+    let ix = solana_sdk::instruction::Instruction {
+        program_id: pitstop::id(),
+        accounts: pitstop::accounts::SweepRemaining {
+            authority: authority.pubkey(),
+            config: config_pda,
+            market: market_pda,
+            vault: vault_ata,
+            treasury: treasury.pubkey(),
+            close_destination: authority.pubkey(),
+            usdc_mint: usdc_mint.pubkey(),
+            token_program: spl_token::id(),
+        }
+        .to_account_metas(None),
+        data: pitstop::instruction::SweepRemaining {}.data(),
+    };
+    let tx = Transaction::new_signed_with_payer(
+        &[ix],
+        Some(&ctx.payer.pubkey()),
+        &[&ctx.payer, &authority],
+        ctx.last_blockhash,
+    );
+    assert!(ctx.banks_client.process_transaction(tx).await.is_err());
+}
+
+#[tokio::test]
+async fn issue_105_anchor_cancel_market_closes_vault_and_sets_voided() {
+    let mut ctx = program_test().start_with_context().await;
+
+    let authority = Keypair::new();
+    let treasury_authority = Keypair::new();
+    for kp in [&authority, &treasury_authority] {
+        fund(&mut ctx, kp, 2_000_000_000).await;
+    }
+
+    let usdc_mint = Keypair::new();
+    create_mint(&mut ctx, &usdc_mint, &authority.pubkey()).await;
+
+    let treasury = Keypair::new();
+    create_token_account(
+        &mut ctx,
+        &treasury,
+        &usdc_mint.pubkey(),
+        &treasury_authority.pubkey(),
+    )
+    .await;
+
+    let (config_pda, _) = Pubkey::find_program_address(&[CONFIG_SEED], &pitstop::id());
+    let ix = solana_sdk::instruction::Instruction {
+        program_id: pitstop::id(),
+        accounts: pitstop::accounts::Initialize {
+            authority: authority.pubkey(),
+            config: config_pda,
+            usdc_mint: usdc_mint.pubkey(),
+            treasury: treasury.pubkey(),
+            token_program: spl_token::id(),
+            system_program: solana_sdk::system_program::id(),
+        }
+        .to_account_metas(None),
+        data: pitstop::instruction::Initialize {
+            args: InitializeArgs {
+                treasury_authority: treasury_authority.pubkey(),
+                max_total_pool_per_market: 1_000_000,
+                max_bet_per_user_per_market: 500_000,
+                claim_window_secs: 3600,
+            },
+        }
+        .data(),
+    };
+    let tx = Transaction::new_signed_with_payer(
+        &[ix],
+        Some(&ctx.payer.pubkey()),
+        &[&ctx.payer, &authority],
+        ctx.last_blockhash,
+    );
+    ctx.banks_client.process_transaction(tx).await.unwrap();
+
+    let event_id = [8u8; 32];
+    let market_type = 0u8;
+    let rules_version = 1u16;
+    let market_id = canonical_market_id(event_id, market_type, rules_version);
+    let (market_pda, _) = Pubkey::find_program_address(&[MARKET_SEED, market_id.as_ref()], &pitstop::id());
+    let vault_ata = spl_associated_token_account::get_associated_token_address_with_program_id(
+        &market_pda,
+        &usdc_mint.pubkey(),
+        &spl_token::id(),
+    );
+
+    let ix = solana_sdk::instruction::Instruction {
+        program_id: pitstop::id(),
+        accounts: pitstop::accounts::CreateMarket {
+            authority: authority.pubkey(),
+            config: config_pda,
+            market: market_pda,
+            vault: vault_ata,
+            usdc_mint: usdc_mint.pubkey(),
+            token_program: spl_token::id(),
+            associated_token_program: spl_associated_token_account::id(),
+            system_program: solana_sdk::system_program::id(),
+        }
+        .to_account_metas(None),
+        data: pitstop::instruction::CreateMarket {
+            args: CreateMarketArgs {
+                market_id,
+                event_id,
+                lock_timestamp: i64::MAX,
+                max_outcomes: 2,
+                market_type,
+                rules_version,
+            },
+        }
+        .data(),
+    };
+    let tx = Transaction::new_signed_with_payer(
+        &[ix],
+        Some(&ctx.payer.pubkey()),
+        &[&ctx.payer, &authority],
+        ctx.last_blockhash,
+    );
+    ctx.banks_client.process_transaction(tx).await.unwrap();
+
+    let ix = solana_sdk::instruction::Instruction {
+        program_id: pitstop::id(),
+        accounts: pitstop::accounts::CancelMarket {
+            authority: authority.pubkey(),
+            config: config_pda,
+            market: market_pda,
+            vault: vault_ata,
+            close_destination: authority.pubkey(),
+            token_program: spl_token::id(),
+        }
+        .to_account_metas(None),
+        data: pitstop::instruction::CancelMarket {}.data(),
+    };
+    let tx = Transaction::new_signed_with_payer(
+        &[ix],
+        Some(&ctx.payer.pubkey()),
+        &[&ctx.payer, &authority],
+        ctx.last_blockhash,
+    );
+    ctx.banks_client.process_transaction(tx).await.unwrap();
+
+    let market_acct = ctx
+        .banks_client
+        .get_account(market_pda)
+        .await
+        .unwrap()
+        .unwrap();
+    let market: Market = AccountDeserialize::try_deserialize(&mut market_acct.data.as_slice()).unwrap();
+    assert_eq!(market.status, MarketStatus::Voided);
+
+    let vault_after = ctx.banks_client.get_account(vault_ata).await.unwrap();
+    assert!(vault_after.is_none());
+}


### PR DESCRIPTION
## Summary
Implements Issue #105 Anchor integration pass for terminal settlement/cancel flows:
- Adds Anchor entrypoints + account contexts for:
  - `claim_resolved`
  - `claim_voided`
  - `sweep_remaining`
  - `cancel_market`
- Wires these handlers into the Rust parity layer with deterministic error mapping.
- Adds Anchor events for terminal flows.
- Adds issue-scoped program-test coverage file for #105.

## File-by-file summary
- `programs/pitstop/src/anchor_accounts.rs`
  - Added args + account contexts for `ClaimResolved`, `ClaimVoided`, `SweepRemaining`, `CancelMarket`.
  - Added PDA/constraint wiring for position-seeded claim paths and sweep/cancel vault-close accounts.

- `programs/pitstop/src/anchor_events.rs`
  - Added Anchor event structs:
    - `Claimed`
    - `MarketSweptEvent`
    - `MarketCancelled`

- `programs/pitstop/src/lib.rs`
  - Added program entrypoints for the four Issue #105 instructions.
  - Implemented handlers to:
    - build parity inputs,
    - map/validate deterministic preconditions at the Anchor boundary,
    - execute token CPI transfers/close-account operations where applicable,
    - commit post-parity account updates,
    - emit the corresponding Anchor events.
  - Uses market PDA signer seeds for vault-authorized CPI in sweep/cancel and claim payout transfers.

- `programs/pitstop/tests/anchor_wire_105.rs`
  - Added issue-scoped program-test coverage for #105 wiring:
    - `issue_105_anchor_claim_and_sweep_status_guards`
    - `issue_105_anchor_cancel_market_closes_vault_and_sets_voided`

## Validation
- `npm test` ✅
- `cargo test --workspace --all-targets --locked` ✅
- `node scripts/spec_gate_check.js` ✅

## Notes
- Existing non-blocking repo warnings remain unchanged (e.g., `unexpected cfg value: solana`, pre-existing `unused mut` in `anchor_wire_103.rs`).
